### PR TITLE
add hhvm to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.3
   - 5.4
+  - hhvm
 
 before_script:
   - wget -nc http://getcomposer.org/composer.phar


### PR DESCRIPTION
Tried this out on Ubuntu x64, and it appears to pass all the tests!

```
$ hhvm vendor/bin/phpunit
PHPUnit 4.0.14 by Sebastian Bergmann.

Configuration read from /home/vagrant/php-travis-client/phpunit.xml.dist

.....................................

Time: 991 ms, Memory: 14.53Mb

OK (37 tests, 88 assertions)
```
