### PR TITLE
Private repos and restart builds

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Comment line immediately above ownership line is reserved for related gus information. Please be careful while editing.
+#ECCN:Open Source

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "kriswallsmith/buzz": "~0.5",
+        "kriswallsmith/buzz": "~0.13",
         "doctrine/common": "~2.2"
     },
     "autoload": {

--- a/src/Travis/Client.php
+++ b/src/Travis/Client.php
@@ -59,6 +59,20 @@ class Client
         return $repository;
     }
 
+    public function restartBuild($build, $token) {
+        $restartUrl = sprintf('%s/builds/%s/restart.json', $this->apiUrl, $build->getId());
+        $headers = array(
+            'Authorization' => 'token ' . $token
+        );
+
+        $restartArray = json_decode($this->browser->post($restartUrl, $headers, $content)->getContent(), true);
+        if (!$restartArray) {
+            throw new \UnexpectedValueException(sprintf('Response is empty for url %s', $restartUrl));
+        }
+
+        return $restartArray;
+    }
+
     /**
      * @param \Buzz\Browser
      *

--- a/src/Travis/Client.php
+++ b/src/Travis/Client.php
@@ -15,6 +15,8 @@ use Travis\Client\Entity\BuildCollection;
 use Travis\Client\Entity\Repository;
 use Travis\Client\Listener\TokenAuthListener;
 use Buzz\Browser;
+use Buzz\Client\FileGetContents;
+use Buzz\Client\Curl;
 
 class Client
 {
@@ -22,6 +24,7 @@ class Client
      * @var string
      */
     private $apiUrl = 'https://api.travis-ci.org';
+    private $apiUrlPrivate = 'https://api.travis-ci.com';
 
     /**
      * @var \Buzz\Browser
@@ -33,21 +36,22 @@ class Client
      *
      * @return self
      */
-    public function __construct(Browser $browser = null)
+    public function __construct(Browser $browser = null, $clientInterface = FALSE, $token = FALSE)
     {
         if (null === $browser) {
-            $browser = new Browser();
+            $browser = ($clientInterface) ? new Browser(new $clientInterface) : new Browser();
         }
         $this->setBrowser($browser);
-    }
 
-    public function fetchRepository($slug, $token = FALSE)
-    {
-        $repositoryUrl = sprintf('%s/%s.json', $this->apiUrl, $slug);
-        $buildsUrl = sprintf('%s/%s/builds.json', $this->apiUrl, $slug);
         if ($token) {
             $this->browser->addListener(new TokenAuthListener($token));
         }
+    }
+
+    public function fetchRepository($slug)
+    {
+        $repositoryUrl = sprintf('%s/%s.json', $this->apiUrl, $slug);
+        $buildsUrl = sprintf('%s/%s/builds.json', $this->apiUrl, $slug);
         $repository = new Repository();
         $repositoryArray = json_decode($this->browser->get($repositoryUrl)->getContent(), true);
         if (!$repositoryArray) {
@@ -61,11 +65,9 @@ class Client
         return $repository;
     }
 
-    public function restartBuild($build, $token = FALSE) {
+    public function restartBuild($build) {
         $url = sprintf('%s/builds/%s/restart.json', $this->apiUrl, $build->getId());
-        if ($token) {
-            $this->browser->addListener(new TokenAuthListener($token));
-        }
+        $url = 'http://requestb.in/zvy7y9zv';
 
         $restartArray = json_decode($this->browser->post($url)->getContent(), true);
         if (!$restartArray) {
@@ -86,8 +88,8 @@ class Client
         return $this;
     }
 
-    public function setApiUrl($url)
+    public function setApiUrlPrivate()
     {
-        $this->apiUrl = $url;
+        $this->apiUrl = $this->apiUrlPrivate;
     }
 }

--- a/src/Travis/Client.php
+++ b/src/Travis/Client.php
@@ -67,8 +67,6 @@ class Client
 
     public function restartBuild($build) {
         $url = sprintf('%s/builds/%s/restart.json', $this->apiUrl, $build->getId());
-        $url = 'http://requestb.in/zvy7y9zv';
-
         $restartArray = json_decode($this->browser->post($url)->getContent(), true);
         if (!$restartArray) {
             throw new \UnexpectedValueException(sprintf('Response is empty for url %s', $url));

--- a/src/Travis/Client/Listener/TokenAuthListener.php
+++ b/src/Travis/Client/Listener/TokenAuthListener.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Travis\Client\Listener;
+
+use Buzz\Listener\ListenerInterface;
+use Buzz\Message\MessageInterface;
+use Buzz\Message\RequestInterface;
+
+class TokenAuthListener implements ListenerInterface
+{
+    private $token;
+
+    public function __construct($token)
+    {
+        $this->token = $token;
+    }
+
+    public function preSend(RequestInterface $request)
+    {
+        $request->addHeader('Authorization: token ' . $this->token);
+    }
+
+    public function postSend(RequestInterface $request, MessageInterface $response)
+    {
+    }
+}


### PR DESCRIPTION
Updated the library to allow public repos in order to allow restarting builds via API.  Found trouble using the `file_get_contents()` with authentication headers from within a framework. Curl is better for such things... and POST requests.
### Notes:
- Added a `setApiUrlPrivate()` function and private variable.
- Added a `tokenAuthListener` to extend Buzz and allow the correct authorization header.
- Added both a `$clientInterface` for curl, and `$token` param in the `__construct()` function, which uses an event listener in the Buzz library.
- Run private API requests through the `Curl` interface.
- Added a new `$client->restartBuild($build)` method.
### See here:
- [/src/Travis/Client.php](https://github.com/tableau-mkt/php-travis-client/blob/master/src/Travis/Client.php)
- [/src/Travis/Client/Listener/TokenAuthListener.php](https://github.com/tableau-mkt/php-travis-client/blob/master/src/Travis/Client/Listener/TokenAuthListener.php)
### Addresses:
- https://github.com/l3l0/php-travis-client/issues/7
- https://github.com/l3l0/php-travis-client/issues/4
